### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nandordudas/vite-template/security/code-scanning/1](https://github.com/nandordudas/vite-template/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow only performs basic CI tasks like linting and building, it likely only requires `contents: read` permissions. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
